### PR TITLE
Fixing iOS bug for saving videos

### DIFF
--- a/ios/Classes/SwiftSaverGalleryPlugin.swift
+++ b/ios/Classes/SwiftSaverGalleryPlugin.swift
@@ -3,7 +3,7 @@ import UIKit
 import Photos
 
 public class SwiftSaverGalleryPlugin: NSObject, FlutterPlugin {
-  let errorMessage = "保存失败,请检查权限是否开启"
+  let errorMessage = "Failed to save, please check whether the permission is enabled"
        
   var result: FlutterResult?;
 

--- a/ios/Classes/SwiftSaverGalleryPlugin.swift
+++ b/ios/Classes/SwiftSaverGalleryPlugin.swift
@@ -173,7 +173,7 @@ public struct SaveResultModel: Encodable {
         let encoder = JSONEncoder()
         guard let data = try? encoder.encode(self) else { return nil }
         if (!JSONSerialization.isValidJSONObject(data)) {
-            return try? JSONSerialization.jsonObject(with: data, options: .mutableContainers) as? [String:Any]
+            return try! JSONSerialization.jsonObject(with: data, options: .mutableContainers) as? [String:Any]
         }
         return nil
     }

--- a/ios/Classes/SwiftSaverGalleryPlugin.swift
+++ b/ios/Classes/SwiftSaverGalleryPlugin.swift
@@ -27,8 +27,7 @@ public class SwiftSaverGalleryPlugin: NSObject, FlutterPlugin {
         saveImage(UIImage(data: newImage) ?? image, isReturnImagePath: isReturnImagePath)
       } else if (call.method == "saveFileToGallery") {
         guard let arguments = call.arguments as? [String: Any],
-              let path = arguments["file"] as? String,
-              let _ = arguments["name"],
+              let path = arguments["path"] as? String,
               let isReturnFilePath = arguments["isReturnPathOfIOS"] as? Bool else { return }
         if (isImageFile(filename: path)) {
             saveImageAtFileUrl(path, isReturnImagePath: isReturnFilePath)

--- a/lib/saver_gallery.dart
+++ b/lib/saver_gallery.dart
@@ -12,7 +12,8 @@ class SaverGallery {
   /// imageBytes can't null
   /// return Map type
   /// for example:{"isSuccess":true, "errorMessage":String?}
-  static Future<Map<String, dynamic>> saveImage(Uint8List imageBytes, {
+  static Future<Map<String, dynamic>> saveImage(
+    Uint8List imageBytes, {
     int quality = 100,
     String? fileExtension,
     required String name,
@@ -44,10 +45,12 @@ class SaverGallery {
   /// Save the PNG，JPG，JPEG image or video located at [file] to the local device media gallery.
   static Future saveFile(String file, {bool isReturnPathOfIOS = false}) async {
     final result = await _channel.invokeMethod(
-        'saveFileToGallery', <String, dynamic>{
-      'path': file,
-      'isReturnPathOfIOS': isReturnPathOfIOS
-    });
+      'saveFileToGallery',
+      <String, dynamic>{
+        'path': file,
+        'isReturnPathOfIOS': isReturnPathOfIOS,
+      },
+    );
     return result;
   }
 }


### PR DESCRIPTION
Saving videos is not working in iOS because:

1. It's expecting some arguments in the swift file `SwiftSaverGalleryPlugin.swift` which are not passed through the channel from flutter side, I've edited the swift file accordingly to fix this issue, and I did make sure it's working fine from my side.
2. There is Null Safety issue which needs to be handled, and I did that in the last commit.